### PR TITLE
Fixed 'Logs have different names when called from namespaces'

### DIFF
--- a/engine/src/toast/log.hpp
+++ b/engine/src/toast/log.hpp
@@ -31,9 +31,7 @@ void TOAST_API
 
 #define TOAST_LOG_IMPL(severity, sink, ...)                                                        \
 	do {                                                                                             \
-		/* The sink must be a valid type or name in scope; this prevents typos in system names */      \
-		using _validate_type = sink;                                                                   \
-		::logging::_detail::log(severity, TOAST_FILE_NAME, __LINE__, #sink, std::format(__VA_ARGS__)); \
+		::logging::_detail::log(severity, TOAST_FILE_NAME, __LINE__, sink, std::format(__VA_ARGS__));  \
 	} while (0)
 
 /**

--- a/engine/src/toast/log.hpp
+++ b/engine/src/toast/log.hpp
@@ -29,9 +29,9 @@ void TOAST_API
 
 #define TOAST_FILE_NAME ::logging::_detail::getOnlyName(__FILE__)
 
-#define TOAST_LOG_IMPL(severity, sink, ...)                                                        \
-	do {                                                                                             \
-		::logging::_detail::log(severity, TOAST_FILE_NAME, __LINE__, sink, std::format(__VA_ARGS__));  \
+#define TOAST_LOG_IMPL(severity, sink, ...)                                                       \
+	do {                                                                                            \
+		::logging::_detail::log(severity, TOAST_FILE_NAME, __LINE__, sink, std::format(__VA_ARGS__)); \
 	} while (0)
 
 /**

--- a/engine/src/toast/logger.cpp
+++ b/engine/src/toast/logger.cpp
@@ -134,20 +134,28 @@ Logger::~Logger() noexcept {
 void Logger::log(std::string_view file, unsigned line, char severity, std::string_view sink, std::string_view message) {
 	auto* logger = instance;
 
+	auto pos = sink.find_last_of(':');
+	std::string_view trimmed_sink;
+	if (pos != std::string::npos) {
+		trimmed_sink = sink.substr(pos + 1);
+	} else {
+		trimmed_sink = sink;
+	}
+
 	if (not logger) {
 		switch (severity) {
 			case 4:     // critical
 			case 3:     // error
-				std::println("\033[31m[ERROR] {}: {}\033[0m", sink, message);
+				std::println("\033[31m[ERROR] {}: {}\033[0m", trimmed_sink, message);
 				return;
 			case 2:     // warning
-				std::println("\033[33m[WARNING] {}: {}\033[0m", sink, message);
+				std::println("\033[33m[WARNING] {}: {}\033[0m", trimmed_sink, message);
 				return;
 			case 1:     // info
-				std::println("\033[32m[INFO] {}: {}\033[0m", sink, message);
+				std::println("\033[32m[INFO] {}: {}\033[0m", trimmed_sink, message);
 				return;
 			default:    // trace
-				std::println("[TRACE] {}: {}", sink, message);
+				std::println("[TRACE] {}: {}", trimmed_sink, message);
 				return;
 		}
 	}
@@ -159,7 +167,7 @@ void Logger::log(std::string_view file, unsigned line, char severity, std::strin
 	log.set_filepath(file);
 	log.set_line_number(line);
 	log.set_severity(static_cast<logging::LogData_Severity>(severity));
-	log.set_sink(sink);
+	log.set_sink(trimmed_sink);
 	log.set_message(message);
 
 	{
@@ -176,9 +184,9 @@ void Logger::log(std::string_view file, unsigned line, char severity, std::strin
 #ifdef DEBUG
 	// If in debug we are going to print warnings and errors on console
 	if (severity >= 3) {
-		std::println("\033[31m[ERROR] {}: {}\033[0m", sink, message);
+		std::println("\033[31m[ERROR] {}: {}\033[0m", trimmed_sink, message);
 	} else if (severity == 2) {
-		std::println("\033[33m[WARNING] {}: {}\033[0m", sink, message);
+		std::println("\033[33m[WARNING] {}: {}\033[0m", trimmed_sink, message);
 	}
 #endif
 }


### PR DESCRIPTION
Closes #128 